### PR TITLE
Added bone reactions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
 import {
     Client,
+    Events,
     GatewayIntentBits,
     MessageReaction,
     PartialMessageReaction,
@@ -63,7 +64,7 @@ client.once('ready', () => {
     console.log('Bot is ready!');
 });
 
-client.on('interactionCreate', async interaction => {
+client.on(Events.InteractionCreate, async interaction => {
     if (!interaction.isCommand()) return;
 
     const { commandName } = interaction;
@@ -94,7 +95,7 @@ client.on('interactionCreate', async interaction => {
     }
 });
 
-client.on('messageReactionAdd', handleMessageReaction);
+client.on(Events.MessageReactionAdd, handleMessageReaction);
 
 async function handleMessageReaction(reaction: MessageReaction | PartialMessageReaction,
         user: User | PartialUser): Promise<void>{

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,8 +75,8 @@ client.on(Events.InteractionCreate, async interaction => {
             await interaction.reply('El concurso ha comenzado!');
         } else if (commandName === WINNER_COMMAND) {
             const winners = getSortedLeaderboard(3, contestManager.memeLeaderboard);
-            const bones = getSortedLeaderboard(2, contestManager.boneLeaderboard);
-            if(winners.length > 0 && bones.length > 0 ){
+            const bones = getSortedLeaderboard(3, contestManager.boneLeaderboard);
+            if(winners.length == 0 && bones.length == 0 ){
                 await interaction.reply('No winners found for this week.');
             }
             else{


### PR DESCRIPTION
Hecho durante un corabastos 
feat: Agregado concurso de huesos
Agregado un handler para el evento MessageReactionRemove
Refactor de lógica de conteo de uso de número de reacciones a set de id, para llevar a que 1 usuario = 1 voto.
Agregado el objeto de Event de discord para usarlo en vez de strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new leaderboard for a bone contest with unique emojis.
	- Enhanced reaction features to include adding and removing reactions.

- **Refactor**
	- Updated event handling to use a more modular `Events` class.
	- Improved leaderboard calculation to support multiple contests.

- **Style**
	- Swapped out generic reaction emojis for specific `LAUGH_EMOJIS` and `BONE_EMOJI`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->