### PR TITLE
fix: correct weekly contest date calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .eslintcache
 .prettiercache
+.idea

--- a/src/services/meme-manager.ts
+++ b/src/services/meme-manager.ts
@@ -492,12 +492,12 @@ export class MemeManager {
         try {
             console.log(`Creating next week's contest after completing ${completedContest.id}`);
 
-            // Import the utility function
-            const { getNextFridayAtNoon } = await import('../utils/meme-utils.js');
+            // Import the utility functions
+            const { getCurrentFridayAtNoon, getNextFridayAtNoon } = await import('../utils/meme-utils.js');
 
             // Calculate next week's dates (Friday to Friday)
-            const nextStartDate = getNextFridayAtNoon().utc().toDate();
-            const nextEndDate = getNextFridayAtNoon().add(1, 'week').utc().toDate();
+            const nextStartDate = getCurrentFridayAtNoon().utc().toDate();
+            const nextEndDate = getNextFridayAtNoon().utc().toDate();
 
             console.log(
                 `Next contest dates: ${nextStartDate.toISOString()} to ${nextEndDate.toISOString()}`


### PR DESCRIPTION
  ## Summary
  Fixes the bug in automated weekly contest creation where dates were being calculated incorrectly.

  ### Changes
  - **Start date** now uses `getCurrentFridayAtNoon()` instead of `getNextFridayAtNoon()` to get the current friday.
  - **End date** uses `getNextFridayAtNoon()` to get next friday.
  -  Removed redundant `.add(1, 'week')` that was causing the end date to be off by a week.
  -  Also adds `.idea` to `.gitignore`.

  ### Before
  - Start date: November 7, 2025 (next friday).
  - End date: November 14, 2025 (next Friday + 1 week).

  ### After
  - Start date: October 31, 2025 (current friday).
  - End date: November 7, 2025 (next friday).

